### PR TITLE
feat: add default event handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,8 @@ It makes consuming and emitting events with parameters much easier.
 import { justEvent } from '@unional/events-plus'
 import { EventEmitter } from 'EventEmitter3'
 
-const emitter = new EventEmitter()
-
 const count = justEvent<number>('count')
+const emitter = new EventEmitter()
 
 emitter.addListener(count.type, count.handle(value => expect(value).toBe(1)))
 
@@ -62,6 +61,17 @@ emitter.emit(count.type, ...count(1))
 // or
 count.listenTo(emitter, value => expect(value).toBe(1))
 count.emitBy(emitter, 1)
+```
+
+You can also create the event with a default handler:
+
+```ts
+
+let sum = 0
+const sum = justEvent('sum', (value: number) => sum +=value)
+
+const emitter = new EventEmitter()
+emitter.addListener(sum.type, sum.handler)
 ```
 
 ### trapError

--- a/ts/justEvent.eventemitter2.spec.ts
+++ b/ts/justEvent.eventemitter2.spec.ts
@@ -6,7 +6,7 @@ test('usage', () => {
 
   const count = justEvent<number>('count')
 
-  emitter.addListener(count.type, count.listener(value => expect(value).toBe(1)))
+  emitter.addListener(count.type, count.handle(value => expect(value).toBe(1)))
 
   emitter.emit(count.type, ...count(1))
 })

--- a/ts/justEvent.eventemitter3.spec.ts
+++ b/ts/justEvent.eventemitter3.spec.ts
@@ -6,7 +6,7 @@ test('usage', () => {
 
   const count = justEvent<number>('count')
 
-  emitter.addListener(count.type, count.listener(value => expect(value).toBe(1)))
+  emitter.addListener(count.type, count.handle(value => expect(value).toBe(1)))
 
   emitter.emit(count.type, ...count(1))
 })

--- a/ts/justEvent.events.spec.ts
+++ b/ts/justEvent.events.spec.ts
@@ -6,7 +6,7 @@ test('usage', () => {
 
   const count = justEvent<number>('count')
 
-  emitter.addListener(count.type, count.listener(value => expect(value).toBe(1)))
+  emitter.addListener(count.type, count.handle(value => expect(value).toBe(1)))
 
   emitter.emit(count.type, ...count(1))
 })

--- a/ts/justEvent.fbemitter.spec.ts
+++ b/ts/justEvent.fbemitter.spec.ts
@@ -6,7 +6,7 @@ test('usage', () => {
 
   const count = justEvent<number>('count')
 
-  emitter.addListener(count.type, count.listener(value => expect(value).toBe(1)))
+  emitter.addListener(count.type, count.handle(value => expect(value).toBe(1)))
 
   emitter.emit(count.type, ...count(1))
 })

--- a/ts/justEvent.spec.ts
+++ b/ts/justEvent.spec.ts
@@ -7,14 +7,48 @@ it('defaults to no value, no meta', () => {
   empty() // call without params
 })
 
-it('with value', () => {
+it('can type Value using generics', () => {
   const event = justEvent<string>('horn')
   const e = event('beep')
   expect(e[0]).toBe('beep')
 })
 
-it('with meta', () => {
-  const log = justEvent<undefined, { logs: string[] }>('with-log')
-  const e = log(undefined, { logs: ['new log'] })
+it('can type Value and Meta using generics', () => {
+  const withLog = justEvent<undefined, { logs: string[] }>('with-log')
+  const e = withLog(undefined, { logs: ['new log'] })
   expect(e[1].logs).toEqual(['new log'])
+})
+
+it('can define a default handler', () => {
+  let called = false
+  const notify = justEvent('notify', () => called = true)
+  notify.handler()
+
+  expect(called).toBe(true)
+})
+
+it('can define handler with value', () => {
+  let actual: string
+  const echo = justEvent('echo', (value: string) => actual = value)
+
+  echo.handler('hello')
+  expect(actual!).toBe('hello')
+})
+
+it('can define handler with value and meta', () => {
+  let actual: any
+  const add = justEvent('add', ([a, b]: [number, number], meta: { logs: string[] }) => {
+    actual = {
+      input: [a, b],
+      output: a + b,
+      meta: { logs: [...meta.logs, `adding ${a} + ${b}`] }
+    }
+  })
+  add.handler([1, 2], { logs: [] })
+
+  expect(actual).toEqual({
+    input: [1, 2],
+    output: 3,
+    meta: { logs: ['adding 1 + 2'] }
+  })
 })

--- a/ts/justEvent.ts
+++ b/ts/justEvent.ts
@@ -1,44 +1,136 @@
 import { JustDuo, JustEmpty, JustMeta, JustUno } from '@just-func/types'
 import { EventEmitterLike, EventTargetLike, isEventEmitterLike, isEventTargetLike } from './types.js'
 
+/**
+ * Event with Value and Meta
+ */
 export interface JustEventDuo<
   Type extends string,
   Value, Meta extends JustMeta> {
+  /**
+   * The event type: `emitter.emit(event.type)`
+   */
   type: Type,
+  /**
+   * Create event argments as in `emitter.emit(event.type, ...event(value, meta))`.
+   */
   (value: Value, meta: Meta): JustDuo<Value, Meta>,
-  listener(callback: (value: Value, meta: Meta) => unknown): (...args: any[]) => any,
-  listenTo(emitter: EventEmitterLike | EventTargetLike, callback: (value: Value, meta: Meta) => unknown): void,
+  /**
+   * creates the event handler with type support
+   */
+  handle(handler: (value: Value, meta: Meta) => unknown): (...args: any[]) => any,
+  /**
+   * A functional and normalized way to call `emitter.addListener(...)`
+   */
+  listenTo(emitter: EventEmitterLike | EventTargetLike, handler: (value: Value, meta: Meta) => unknown): void,
+  /**
+   * A functional and normalized way to call `emitter.emit(...)`
+   */
   emitBy(emitter: EventEmitterLike | EventTargetLike, value: Value, meta: Meta): void
 }
 
+/**
+ * Event with Value only
+ */
 export interface JustEventUno<
   Type extends string,
   Value> {
+  /**
+   * The event type: `emitter.emit(event.type)`
+   */
   type: Type,
+  /**
+   * Create event argments as in `emitter.emit(event.type, ...event(value))`.
+   */
   (value: Value): JustUno<Value>,
-  listener(callback: (value: Value) => unknown): (...args: any[]) => any,
-  listenTo(emitter: EventEmitterLike | EventTargetLike, callback: (value: Value) => unknown): void,
+  /**
+   * creates the event handler with type support
+   */
+  handle(handler: (value: Value) => unknown): (...args: any[]) => any,
+  /**
+   * A functional and normalized way to call `emitter.addListener(...)`
+   */
+  listenTo(emitter: EventEmitterLike | EventTargetLike, handler: (value: Value) => unknown): void,
+  /**
+   * A functional and normalized way to call `emitter.emit(...)`
+   */
   emitBy(emitter: EventEmitterLike | EventTargetLike, value: Value): void
 }
 
+/**
+ * Event with no value
+ */
 export interface JustEventEmpty<
   Type extends string> {
+  /**
+   * The event type: `emitter.emit(event.type)`
+   */
   type: Type,
+  /**
+   * Create event argments as in `emitter.emit(event.type, ...event())`.
+   * Since this event has no value, this function returns an empty array.
+   */
   (): JustEmpty,
-  listener(callback: () => unknown): (...args: any[]) => any,
-  listenTo(emitter: EventEmitterLike | EventTargetLike, callback: () => unknown): void,
+  /**
+   * creates the event handler with type support
+   */
+  handle(handler: () => unknown): (...args: any[]) => any,
+  /**
+   * A functional and normalized way to call `emitter.addListener(...)`
+   */
+  listenTo(emitter: EventEmitterLike | EventTargetLike, handler: () => unknown): void,
+  /**
+   * A functional and normalized way to call `emitter.emit(...)`
+   */
   emitBy(emitter: EventEmitterLike | EventTargetLike): void
 }
 
+/**
+ * Creates just an event that is typed and easy to use.
+ */
 export function justEvent(type: string): JustEventEmpty<typeof type>
+/**
+ * Creates just an event that is typed and easy to use.
+ */
+export function justEvent(type: string, handler: () => unknown): JustEventEmpty<typeof type> & {
+  /**
+   * The default event handler
+   */
+  handler: () => unknown
+}
+/**
+ * Creates just an event that is typed and easy to use.
+ */
+export function justEvent<Value>(type: string, handler: (value: Value) => unknown): JustEventUno<typeof type, Value> & {
+  /**
+   * The default event handler
+   */
+  handler: (value: Value) => unknown
+}
+/**
+ * Creates just an event that is typed and easy to use.
+ */
 export function justEvent<Value>(type: string): JustEventUno<typeof type, Value>
+/**
+ * Creates just an event that is typed and easy to use.
+ */
 export function justEvent<Value, Meta extends JustMeta>(type: string): JustEventDuo<typeof type, Value, Meta>
-export function justEvent<Value, Meta extends JustMeta>(type: string): any {
+/**
+ * Creates just an event that is typed and easy to use.
+ */
+export function justEvent<Value, Meta extends JustMeta>(type: string, handler: (value: Value, meta: Meta) => unknown): JustEventDuo<typeof type, Value, Meta> & {
+  /**
+   * The default event handler
+   */
+  handler: (value: Value, meta: Meta) => unknown
+}
+export function justEvent<Value, Meta extends JustMeta>(type: string, handler?: (...args: any[]) => any): any {
   return Object.assign(function event(value: Value, meta: Meta): JustDuo<Value, Meta> {
     return [value, meta]
   }, {
     type,
-    listener(callback: (...args: any[]) => any) { return callback },
+    handler,
+    handle(callback: (...args: any[]) => any) { return callback },
     listenTo(emitter: EventEmitterLike | EventTargetLike, callback: (...args: any[]) => any) {
       if (isEventEmitterLike(emitter)) emitter.addListener(this.type, callback)
       if (isEventTargetLike(emitter)) emitter.addEventListener(this.type, callback)


### PR DESCRIPTION
BREAKING CHANGE: rename listener to handle

This is what used in README,
and it is better compare to listener.

With the default handler,
`event.handle()` and `event.handler` separation is good.