### PR TITLE
fix: unbreak docgen and run the commit-msg hook with pnpm

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,2 +1,2 @@
 #!/bin/sh
-yarn commitlint --edit $1
+pnpm exec commitlint --edit $1

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "ts-jest": "^28.0.8",
     "tslib": "^2.4.1",
     "typedoc": "^0.28.0",
-    "typedoc-plugin-extras": "^2.3.1",
     "typescript": "^4.9.4"
   },
   "packageManager": "pnpm@11.20.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,9 +102,6 @@ importers:
       typedoc:
         specifier: ^0.28.0
         version: 0.28.20(typescript@4.9.5)
-      typedoc-plugin-extras:
-        specifier: ^2.3.1
-        version: 2.3.3(typedoc@0.28.20(typescript@4.9.5))
       typescript:
         specifier: ^4.9.4
         version: 4.9.5
@@ -3002,11 +2999,6 @@ packages:
 
   type-plus@6.8.1:
     resolution: {integrity: sha512-yEv9ZE4Lw7fUGQOUYGtUoRJrC46Uta2U2HnpuvIVnwFVmzMP9oE5on7xOxsT39o0hk2lkFghZqlba9GvmW0/rw==}
-
-  typedoc-plugin-extras@2.3.3:
-    resolution: {integrity: sha512-n9zOdVSbGQ8rhsSxtmGCQPVEim345MwpeKl9PUC6ToLR8tu3YYA3BEuR9fP0z+FSx1ExU/kGzxY3sn4+FyHE2w==}
-    peerDependencies:
-      typedoc: 0.24.x
 
   typedoc@0.28.20:
     resolution: {integrity: sha512-uSKqkh8Cr48vllnEy+jdaAgOeR6Y+QCBW7usgUsKj7gJEfR7stw9U/fE49LBnj2tPRKPY0c0EBJSWe9Appmplg==}
@@ -6611,10 +6603,6 @@ snapshots:
     dependencies:
       tersify: 3.12.1
       unpartial: 1.0.5
-
-  typedoc-plugin-extras@2.3.3(typedoc@0.28.20(typescript@4.9.5)):
-    dependencies:
-      typedoc: 0.28.20(typescript@4.9.5)
 
   typedoc@0.28.20(typescript@4.9.5):
     dependencies:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,8 @@
     "noEmit": true
   },
   "typedocOptions": {
-    "customTitle": "Provides additional features to event emitters",
-    "customTitleLink": "https://github.com/unional/events-plus",
+    "name": "Provides additional features to event emitters",
+    "titleLink": "https://github.com/cyberuni/events-plus",
     "entryPoints": [
       "ts/index.ts"
     ],


### PR DESCRIPTION
The release itself succeeded and opened #65 — these are the two faults **downstream of it**, neither of which PR CI can reach, since `docgen` only runs on push to `main`.

## docgen: typedoc 0.28 vs a 2.x plugin

`customTitle` and `customTitleLink` in `tsconfig.json` come from **typedoc-plugin-extras**, pinned at `^2.3.1`. That does not load under typedoc 0.28 (renovate's bump), so typedoc rejected both as unknown options and exited 1.

typedoc has built-ins for exactly these — `name` and `titleLink` — so the plugin is **dropped** rather than upgraded to v4. Nothing else referenced it; `grep` across the repo comes back clean. The link now points at `cyberuni`.

Verified locally: `pnpm build:doc` emits to `./docs` with 0 errors.

> Remaining warning, not fixed here: typedoc 0.28 does not support TypeScript 4.9, which this repo still pins. It builds anyway. The TypeScript major belongs with the toolchain mission.

## The commit-msg hook still called yarn

```sh
yarn commitlint --edit $1
```

Yarn 1.22 refuses to run because `packageManager` names pnpm, reporting the field back mangled as `yarn@pnpm@11.20.0` — which reads like a corrupt `package.json` and sends you looking in the wrong file. It is fine.

`changesets/action` commits the version bump with `git commit`, so this hook runs **inside the release job**. It took the whole release down on `semantic-release-bamboo`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)